### PR TITLE
Changes in poster filename due to changes in xbmc frodo handling of exported posters

### DIFF
--- a/XBMC .nfo Importer.bundle/Contents/Code/__init__.py
+++ b/XBMC .nfo Importer.bundle/Contents/Code/__init__.py
@@ -73,7 +73,7 @@ class xbmcnfo(Agent.Movies):
 		nfoXML = xml.xpath('//MediaPart')[0]
 		path1 = String.Unquote(nfoXML.get('file'))
 
-		posterFilename = self.getRelatedFile(path1, '.tbn')
+		posterFilename = self.getRelatedFile(path1, '-poster.jpg')
 		posterData = None
 		if os.path.exists(posterFilename):
 			posterData = Core.storage.load(posterFilename)


### PR DESCRIPTION
-XBMC Frodo changes-

When library is exported to separate files, posters are now exported as filename-poster.jpg rather than filename.tbn
