### PR TITLE
Eden and Frodo compatibility added

### DIFF
--- a/XBMC .nfo Importer.bundle/Contents/Code/__init__.py
+++ b/XBMC .nfo Importer.bundle/Contents/Code/__init__.py
@@ -3,6 +3,7 @@
 #
 # Original code author: Harley Hooligan
 # Modified by Guillaume Boudreau
+# Eden and Frodo compatibility added by Jorge Amigo
 #
 import os, re, time, datetime
 
@@ -73,9 +74,15 @@ class xbmcnfo(Agent.Movies):
 		nfoXML = xml.xpath('//MediaPart')[0]
 		path1 = String.Unquote(nfoXML.get('file'))
 
-		posterFilename = self.getRelatedFile(path1, '.tbn')
 		posterData = None
-		if os.path.exists(posterFilename):
+		posterFilenameEden = self.getRelatedFile(path1, '.tbn')
+		posterFilenameFrodo = self.getRelatedFile(path1, '-poster.jpg')
+		posterFilename = ""
+		if os.path.exists(posterFilenameEden):
+			posterFilename = posterFilenameEden
+		if os.path.exists(posterFilenameFrodo):
+			posterFilename = posterFilenameFrodo
+		if posterFilename:
 			posterData = Core.storage.load(posterFilename)
 			for key in metadata.posters.keys():
 				del metadata.posters[key]


### PR DESCRIPTION
XBMC Frodo now provides thumbs and posters with .jpg extension instead of Eden's .tbn extension. the code now checks first for Eden's and then for Frodo's extensions.
