### PR TITLE
Duplicated Genre in Plex

### DIFF
--- a/XBMC .nfo Importer.bundle/Contents/Code/__init__.py
+++ b/XBMC .nfo Importer.bundle/Contents/Code/__init__.py
@@ -191,7 +191,7 @@ class xbmcnfo(Agent.Movies):
 						gs = genreXML.text.split("/")
 						if gs != "":
 							for g in gs:
-								metadata.genres.add(g)
+								metadata.genres.add(g.strip())
 				except: pass
 				#countries
 				try:


### PR DESCRIPTION
Plex differs between "Genre" and "Genre ". These Whitespaces will now be eliminated.
