### PR TITLE
Problem with "movie.nfo" files resolved.

### DIFF
--- a/XBMC .nfo Importer.bundle/Contents/Code/__init__.py
+++ b/XBMC .nfo Importer.bundle/Contents/Code/__init__.py
@@ -103,9 +103,15 @@ class xbmcnfo(Agent.Movies):
 
 		nfoFile = self.getRelatedFile(path1, '.nfo')
 		Log('Looking for Movie NFO file at ' + nfoFile)
+		nfoFile2 = folderpath + '\movie.nfo'
+		Log('Additionally looking for Movie NFO file at ' + nfoFile2)
 
 		if not os.path.exists(nfoFile):
 			Log("ERROR: Can't find .nfo file for " + path1)
+			Log("Some users may have movie.nfo files. (FilmInfo!Organizer users for example) We will try this.")
+			nfoFile = nfoFile2
+		if not os.path.exists(nfoFile):
+			Log("ERROR: Also can't find " + nfoFile)
 		else:
 			nfoText = Core.storage.load(nfoFile)
 			nfoText=re.sub(r'&([^a-zA-Z#])',r'&amp;\1',nfoText)


### PR DESCRIPTION
Some users who are not using xbmc to create nfo files may not have
<moviename>.nfo files. instead they have "movie.nfo" files. Film Info!
Organizer for example only creates this kind of files.
Now we are also looking for this "movie.nfo".

Film Info! Organizer is an popular german tool to create nfo files.
