### PR TITLE
Fixed recognition of movies with movie.nfo file.

### DIFF
--- a/XBMC .nfo Importer.bundle/Contents/Code/__init__.py
+++ b/XBMC .nfo Importer.bundle/Contents/Code/__init__.py
@@ -16,11 +16,18 @@ class xbmcnfo(Agent.Movies):
 		Log("Searching")
 
 		path1 = String.Unquote(media.filename)
+		folderpath = os.path.dirname(path1)
 		nfoFile = self.getRelatedFile(path1, '.nfo')
 		Log('Looking for Movie NFO file at ' + nfoFile)
+		nfoFile2 = folderpath + '/movie.nfo'
+		Log('Additionally looking for Movie NFO file at ' + nfoFile2)
 
 		if not os.path.exists(nfoFile):
 			Log("ERROR: Can't find .nfo file for " + path1)
+			Log("Some users may have movie.nfo files. (FilmInfo!Organizer users for example) We will try this.")
+			nfoFile = nfoFile2
+		if not os.path.exists(nfoFile):
+			Log("ERROR: Also can't find " + nfoFile)
 		else:
 			nfoText = Core.storage.load(nfoFile)
 			# work around failing XML parses for things with &'s in
@@ -103,7 +110,7 @@ class xbmcnfo(Agent.Movies):
 
 		nfoFile = self.getRelatedFile(path1, '.nfo')
 		Log('Looking for Movie NFO file at ' + nfoFile)
-		nfoFile2 = folderpath + '\movie.nfo'
+		nfoFile2 = folderpath + '/movie.nfo'
 		Log('Additionally looking for Movie NFO file at ' + nfoFile2)
 
 		if not os.path.exists(nfoFile):


### PR DESCRIPTION
Fixed a typo where a Windows  \ was used instead of / and duplicated the code to handle movie.nfo files. The agent now recognizes all of my 800 movies. Without the fix a lot of them where missed.
