### PR TITLE
Fixes: MPAA Rating & Dual Images

### DIFF
--- a/XBMC .nfo Importer.bundle/Contents/Code/__init__.py
+++ b/XBMC .nfo Importer.bundle/Contents/Code/__init__.py
@@ -114,7 +114,7 @@ class xbmcnfo(Agent.Movies):
 
 		path1 = media.items[0].parts[0].file
 		folderpath = os.path.dirname(path1)
-		folderpathDVD = folderpath.replace ('/VIDEO_TS', '')
+		if '/VIDEO_TS' in folderpath: folderpathDVD = folderpath.replace ('/VIDEO_TS', '')
 		Log('folderpath: ' + folderpath)
 
 		# Moviename from folder
@@ -128,19 +128,19 @@ class xbmcnfo(Agent.Movies):
 		# Eden
 		# posterNames.append (self.getRelatedFile(path1, '.tbn'))
 		# posterNames.append (folderpath + "/folder.jpg")
-		posterNames.append (folderpathDVD + '/folder.jpg')
+		if '/VIDEO_TS' in folderpath: posterNames.append (folderpathDVD + '/folder.jpg')
 		# Frodo
 		posterNames.append (self.getRelatedFile(path1, '-poster.jpg'))
 		posterNames.append (moviename + '-poster.jpg')
 		# posterNames.append (folderpath + '/poster.jpg')
-		posterNames.append (folderpathDVD + '/poster.jpg')
+		if '/VIDEO_TS' in folderpath: posterNames.append (folderpathDVD + '/poster.jpg')
 		# Others
 		# posterNames.append (folderpath + "/cover.jpg")
-		posterNames.append (folderpathDVD + '/cover.jpg')
+		if '/VIDEO_TS' in folderpath: posterNames.append (folderpathDVD + '/cover.jpg')
 		# posterNames.append (folderpath + "/default.jpg")
-		posterNames.append (folderpathDVD + '/default.jpg')
+		if '/VIDEO_TS' in folderpath: posterNames.append (folderpathDVD + '/default.jpg')
 		# posterNames.append (folderpath + "/movie.jpg")
-		posterNames.append (folderpathDVD + '/movie.jpg')
+		if '/VIDEO_TS' in folderpath: posterNames.append (folderpathDVD + '/movie.jpg')
 
 		# check possible poster file locations
 		posterFilename = self.checkFilePaths (posterNames, 'poster')
@@ -157,14 +157,14 @@ class xbmcnfo(Agent.Movies):
 		# fanartNames.append (self.getRelatedFile(path1, '-fanart.jpg'))
 		# fanartNames.append (moviename + '-fanart.jpg')
 		# fanartNames.append (folderpath + '/fanart.jpg')
-		fanartNames.append (folderpathDVD + '/fanart.jpg')
+		if '/VIDEO_TS' in folderpath: fanartNames.append (folderpathDVD + '/fanart.jpg')
 		# Others
 		# fanartNames.append (folderpath + '/art.jpg')
-		fanartNames.append (folderpathDVD + '/art.jpg')
+		if '/VIDEO_TS' in folderpath: fanartNames.append (folderpathDVD + '/art.jpg')
 		# fanartNames.append (folderpath + '/backdrop.jpg')
-		fanartNames.append (folderpathDVD + '/backdrop.jpg')
+		if '/VIDEO_TS' in folderpath: fanartNames.append (folderpathDVD + '/backdrop.jpg')
 		# fanartNames.append (folderpath + '/background.jpg')
-		fanartNames.append (folderpathDVD + '/background.jpg')
+		if '/VIDEO_TS' in folderpath: fanartNames.append (folderpathDVD + '/background.jpg')
 
 		# check possible fanart file locations
 		fanartFilename = self.checkFilePaths (fanartNames, 'fanart')


### PR DESCRIPTION
MPAA Rating:
Works for ANY rating regardless of the US types
(Thanks to Luzifel for pointing out)

Dual Images:
Commented out the parts for images (posters/banners/etc)that already exist in the LocalMedia.bundle Scanner, to avoid having double records that clatter & increase the size of the library for no reason.
