### PR TITLE
Fix: Summary, Multiline Items | Clean Up: VIDEO_TS, Comments, Log

### DIFF
--- a/XBMC .nfo Importer.bundle/Contents/Code/__init__.py
+++ b/XBMC .nfo Importer.bundle/Contents/Code/__init__.py
@@ -86,18 +86,18 @@ class xbmcnfo(Agent.Movies):
 					return
 
 				# Title
-				try: media.name = nfoXML.xpath('./title')[0].text
+				try: media.name = nfoXML.xpath('title')[0].text
 				except:
 					Log("ERROR: No <title> tag in " + nfoFile + ". Aborting!")
 					return
-				# IMDB id
-				try:
-					imdb_id = nfoXML.xpath('./id')[0].text
-					if len(imdb_id) > 2:
-						media.id = imdb_id
-				except: pass
 				# Year
-				try: media.year = nfoXML.xpath('./year')[0].text
+				try: media.year = nfoXML.xpath('year')[0].text
+				except: pass
+				# ID
+				try:
+					id = nfoXML.xpath('id')[0].text
+					if len(id) > 2:
+						media.id = id
 				except: pass
 
 				results.Append(MetadataSearchResult(id=media.id, name=media.name, year=media.year, lang=lang, score=100))
@@ -114,8 +114,9 @@ class xbmcnfo(Agent.Movies):
 
 		path1 = media.items[0].parts[0].file
 		folderpath = os.path.dirname(path1)
-		if '/VIDEO_TS' in folderpath: folderpathDVD = folderpath.replace ('/VIDEO_TS', '')
 		Log('folderpath: ' + folderpath)
+		isDVD = os.path.basename(folderpath).upper() == 'VIDEO_TS'
+		if isDVD: folderpathDVD = os.path.dirname(folderpath)
 
 		# Moviename from folder
 		moviename = self.getMovieNameFromFolder (folderpath)
@@ -128,19 +129,19 @@ class xbmcnfo(Agent.Movies):
 		# Eden
 		# posterNames.append (self.getRelatedFile(path1, '.tbn'))
 		# posterNames.append (folderpath + "/folder.jpg")
-		if '/VIDEO_TS' in folderpath: posterNames.append (folderpathDVD + '/folder.jpg')
+		if isDVD: posterNames.append (folderpathDVD + '/folder.jpg')
 		# Frodo
 		posterNames.append (self.getRelatedFile(path1, '-poster.jpg'))
 		posterNames.append (moviename + '-poster.jpg')
 		# posterNames.append (folderpath + '/poster.jpg')
-		if '/VIDEO_TS' in folderpath: posterNames.append (folderpathDVD + '/poster.jpg')
+		if isDVD: posterNames.append (folderpathDVD + '/poster.jpg')
 		# Others
 		# posterNames.append (folderpath + "/cover.jpg")
-		if '/VIDEO_TS' in folderpath: posterNames.append (folderpathDVD + '/cover.jpg')
+		if isDVD: posterNames.append (folderpathDVD + '/cover.jpg')
 		# posterNames.append (folderpath + "/default.jpg")
-		if '/VIDEO_TS' in folderpath: posterNames.append (folderpathDVD + '/default.jpg')
+		if isDVD: posterNames.append (folderpathDVD + '/default.jpg')
 		# posterNames.append (folderpath + "/movie.jpg")
-		if '/VIDEO_TS' in folderpath: posterNames.append (folderpathDVD + '/movie.jpg')
+		if isDVD: posterNames.append (folderpathDVD + '/movie.jpg')
 
 		# check possible poster file locations
 		posterFilename = self.checkFilePaths (posterNames, 'poster')
@@ -157,14 +158,14 @@ class xbmcnfo(Agent.Movies):
 		# fanartNames.append (self.getRelatedFile(path1, '-fanart.jpg'))
 		# fanartNames.append (moviename + '-fanart.jpg')
 		# fanartNames.append (folderpath + '/fanart.jpg')
-		if '/VIDEO_TS' in folderpath: fanartNames.append (folderpathDVD + '/fanart.jpg')
+		if isDVD: fanartNames.append (folderpathDVD + '/fanart.jpg')
 		# Others
 		# fanartNames.append (folderpath + '/art.jpg')
-		if '/VIDEO_TS' in folderpath: fanartNames.append (folderpathDVD + '/art.jpg')
+		if isDVD: fanartNames.append (folderpathDVD + '/art.jpg')
 		# fanartNames.append (folderpath + '/backdrop.jpg')
-		if '/VIDEO_TS' in folderpath: fanartNames.append (folderpathDVD + '/backdrop.jpg')
+		if isDVD: fanartNames.append (folderpathDVD + '/backdrop.jpg')
 		# fanartNames.append (folderpath + '/background.jpg')
-		if '/VIDEO_TS' in folderpath: fanartNames.append (folderpathDVD + '/background.jpg')
+		if isDVD: fanartNames.append (folderpathDVD + '/background.jpg')
 
 		# check possible fanart file locations
 		fanartFilename = self.checkFilePaths (fanartNames, 'fanart')
@@ -191,7 +192,7 @@ class xbmcnfo(Agent.Movies):
 
 		if nfoFile:
 			nfoText = Core.storage.load(nfoFile)
-			nfoText=re.sub(r'&([^a-zA-Z#])',r'&amp;\1',nfoText)
+			nfoText = re.sub(r'&([^a-zA-Z#])',r'&amp;\1',nfoText)
 			nfoTextLower = nfoText.lower()
 			if nfoTextLower.count('<movie') > 0 and nfoTextLower.count('</movie>') > 0:
 				# Remove URLs (or other stuff) at the end of the XML file
@@ -204,104 +205,104 @@ class xbmcnfo(Agent.Movies):
 					return
 
 				# Title
-				try: metadata.title = nfoXML.xpath('./title')[0].text
-				except: pass
-				# Original Title
-				try: metadata.original_title = nfoXML.xpath('./originaltitle')[0].text
-				except: pass
-				#summary
-				try: metadata.summary = nfoXML.xpath('./plot')[0].text
-				except: pass
-				#tagline
-				try: metadata.tagline = nfoXML.findall("tagline")[0].text
-				except: pass
-				#year
+				try: metadata.title = nfoXML.xpath('title')[0].text
+				except:
+					Log("ERROR: No <title> tag in " + nfoFile + ". Aborting!")
+					return
+				# Year
 				try: metadata.year = int(nfoXML.xpath("year")[0].text)
 				except: pass
-				#release date
+				# Original Title
+				try: metadata.original_title = nfoXML.xpath('originaltitle')[0].text
+				except: pass
+				# Rating
+				try: metadata.rating = float(nfoXML.xpath('rating')[0].text.replace(',', '.'))
+				except: pass
+				# Content Rating
+				try:
+					mpaa = nfoXML.xpath('./mpaa')[0].text
+					match = re.match(r'(?:Rated\s)?(?P<mpaa>[A-z0-9-+/.]+(?:\s[0-9]+[A-z]?)?)?', mpaa)
+					if match.group('mpaa'):
+						content_rating = match.group('mpaa')
+					else:
+						content_rating = 'NR'
+					metadata.content_rating = content_rating
+				except: pass
+				# Studio
+				try: metadata.studio = nfoXML.xpath("studio")[0].text
+				except: pass
+				# Premiere
 				try:
 					try:
 						release_date = time.strptime(nfoXML.xpath("releasedate")[0].text, "%d %B %Y")
 					except:
-						try:
-							release_date = time.strptime(nfoXML.xpath("releasedate")[0].text, "%Y-%m-%d")
-						except:
-							if metadata.year:
-								release_date = time.strptime(str(metadata.year) + "-01-01", "%Y-%m-%d")
+						release_date = time.strptime(nfoXML.xpath("releasedate")[0].text, "%Y-%m-%d")
+					except:
+						release_date = time.strptime(str(metadata.year) + "-01-01", "%Y-%m-%d") if metadata.year else None
 					if release_date:
 						metadata.originally_available_at = datetime.datetime.fromtimestamp(time.mktime(release_date)).date()
 				except: pass
-				#rating
-				try: metadata.rating = float(nfoXML.xpath('./rating')[0].text.replace(',','.'))
+				# Tagline
+				try: metadata.tagline = nfoXML.xpath("tagline")[0].text
 				except: pass
-				#content rating
+				# Summary (Outline/Plot)
 				try:
-					match = re.match(r'(?:Rated\s)?(?P<mpaa>[A-z0-9-+/.]+(?:\s[0-9]+[A-z]?)?)?', nfoXML.xpath('./mpaa')[0].text)
-					if match.group('mpaa'):
-						metadata.content_rating = match.group('mpaa')
-					else:
-						metadata.content_rating = 'NR'
+					try:
+						summary = nfoXML.xpath('outline')[0].text.strip('| \t\r\n')
+						if not summary: raise
+					except:
+						summary = nfoXML.xpath('plot')[0].text.strip('| \t\r\n')
+					metadata.summary = summary
 				except: pass
-				#director
+				# Writers (Credits)
 				try: 
-					directors = nfoXML.xpath('./director')
-					metadata.directors.clear()
-					for directorXML in directors:
-						ds = directorXML.text.split("/")
-						if ds != "":
-							for d in ds:
-								metadata.directors.add(d)
-				except: pass
-				#writers/credits
-				try: 
-					credits = nfoXML.xpath('./credits')
+					credits = nfoXML.xpath('credits')
 					metadata.writers.clear()
-					for creditXML in credits:
-						writer = creditXML.text
-						metadata.writers.add(writer)
+					[metadata.writers.add(c.strip()) for creditXML in credits for c in creditXML.text.split("/")]
+					metadata.writers.discard('')
 				except: pass
-				#studio
-				try: metadata.studio = nfoXML.findall("studio")[0].text
+				# Directors
+				try: 
+					directors = nfoXML.xpath('director')
+					metadata.directors.clear()
+					[metadata.directors.add(d.strip()) for directorXML in directors for d in directorXML.text.split("/")]
+					metadata.directors.discard('')
 				except: pass
-				#duration
+				# Genres
+				try:
+					genres = nfoXML.xpath('genre')
+					metadata.genres.clear()
+					[metadata.genres.add(g.strip()) for genreXML in genres for g in genreXML.text.split("/")]
+					metadata.genres.discard('')
+				except: pass
+				# Countries
+				try:
+					countries = nfoXML.xpath('country')
+					metadata.countries.clear()
+					[metadata.countries.add(c.strip()) for countryXML in countries for c in countryXML.text.split("/")]
+					metadata.countries.discard('')
+				except: pass
+				# Collections (Set)
+				try:
+					sets = nfoXML.xpath('set')
+					metadata.collections.clear()
+					[metadata.collections.add(s.strip()) for setXML in sets for s in setXML.text.split("/")]
+					metadata.collections.discard('')
+				except: pass
+				# Duration
 				try:
 					runtime = nfoXML.xpath("runtime")[0].text
 					metadata.duration = int(re.compile('^([0-9]+)').findall(runtime)[0]) * 60 * 1000 # ms
 				except: pass
-				#set/collections
-				try:
-					set_ = nfoXML.xpath('./set')[0].text
-					metadata.collections.clear()
-					metadata.collections.add(set_)
-				except: pass
-				#genre, cant see mulltiple only sees string not seperate genres
-				try:
-					genres = nfoXML.xpath('./genre')
-					metadata.genres.clear()
-					for genreXML in genres:
-						gs = genreXML.text.split("/")
-						if gs != "":
-							for g in gs:
-								metadata.genres.add(g.strip())
-				except: pass
-				#countries
-				try:
-					countries = nfoXML.xpath('./country')
-					metadata.countries.clear()
-					for countryXML in countries:
-						cs = countryXML.text.split("/")
-						if cs != "":
-							for c in cs:
-								metadata.countries.add(c)
-				except: pass
-				#actors
+				# Actors
 				metadata.roles.clear()
-				for actor in nfoXML.findall('./actor'):
+				for actor in nfoXML.xpath('actor'):
 					role = metadata.roles.new()
-					try: role.role = actor.xpath("role")[0].text
-					except: pass
 					try: role.actor = actor.xpath("name")[0].text
 					except: pass
+					try: role.role = actor.xpath("role")[0].text
+					except: pass
+					
 				# Remote posters and fanarts are disabled for now; having them seems to stop the local artworks from being used.
 				#(remote) posters
 				#try:
@@ -327,27 +328,74 @@ class xbmcnfo(Agent.Movies):
 				#(local) fanart
 				if fanartData:
 					metadata.art[fanartFilename] = Proxy.Media(fanartData)
+				
+				# Log("---------------------")
+				# Log("Movie nfo Information")
+				# Log("---------------------")
+				# Log("Title: " + str(metadata.title))
+				# Log("id: " + str(metadata.guid))
+				# Log("Summary: " + str(metadata.summary))
+				# Log("Year: " + str(metadata.year))
+				# Log("IMDB rating: " + str(metadata.rating)) 
+				# Log("Content Rating: " + str(metadata.content_rating))
+				# Log("Directors")
+				# for d in metadata.directors:
+					# Log("  " + d)
+				# Log("Studio: " + str(metadata.studio))
+				# Log("Duration: " + str(metadata.duration))
+				# Log("Actors")
+				# for r in metadata.roles:
+					# try: Log("  " + r.actor + " as " + r.role)
+					# except: pass
+				# Log("Genres")
+				# for r in metadata.genres:
+					# Log("  " + r)
+				# Log("---------------------")
+				
 				Log("---------------------")
 				Log("Movie nfo Information")
 				Log("---------------------")
-				Log("Title: " + str(metadata.title))
-				Log("id: " + str(metadata.guid))
-				Log("Summary: " + str(metadata.summary))
-				Log("Year: " + str(metadata.year))
-				Log("IMDB rating: " + str(metadata.rating)) 
-				Log("Content Rating: " + str(metadata.content_rating))
-				Log("Directors")
-				for d in metadata.directors:
-					Log("  " + d)
-				Log("Studio: " + str(metadata.studio))
-				Log("Duration: " + str(metadata.duration))
-				Log("Actors")
-				for r in metadata.roles:
-					try: Log("  " + r.actor + " as " + r.role)
-					except: pass
-				Log("Genres")
-				for r in metadata.genres:
-					Log("  " + r)
+				try: Log("ID: " + str(metadata.guid))
+				except: Log("ID: -")
+				try: Log("Title: " + str(metadata.title))
+				except: Log("Title: -")
+				try: Log("Year: " + str(metadata.year))
+				except: Log("Year: -")
+				try: Log("Original: " + str(metadata.original_title))
+				except: Log("Original: -")
+				try: Log("Rating: " + str(metadata.rating))
+				except: Log("Rating: -")
+				try: Log("Content: " + str(metadata.content_rating))
+				except: Log("Content: -")
+				try: Log("Studio: " + str(metadata.studio))
+				except: Log("Studio: -")
+				try: Log("Premiere: " + str(metadata.originally_available_at))
+				except: Log("Premiere: -")
+				try: Log("Tagline: " + str(metadata.tagline))
+				except: Log("Tagline: -")
+				try: Log("Summary: " + str(metadata.summary))
+				except: Log("Summary: -")
+				Log("Writers:")
+				try: [Log("\t" + writer) for writer in metadata.writers]
+				except: Log("\t-")
+				Log("Directors:")
+				try: [Log("\t" + director) for director in metadata.directors]
+				except: Log("\t-")
+				Log("Genres:")
+				try: [Log("\t" + genre) for genre in metadata.genres]
+				except: Log("\t-")
+				Log("Countries:")
+				try: [Log("\t" + country) for country in metadata.countries]
+				except: Log("\t-")
+				Log("Collections:")
+				try: [Log("\t" + collection) for collection in metadata.collections]
+				except: Log("\t-")
+				try: Log("Duration: " + str(metadata.duration // 60000) + ' min')
+				except: Log("Duration: -")
+				Log("Actors:")
+				try: [Log("\t" + actor.actor + " > " + actor.role) for actor in metadata.roles]
+				except: [Log("\t" + actor.actor) for actor in metadata.roles]
+				except: Log("\t-")
 				Log("---------------------")
 			else:
 				Log("ERROR: No <movie> tag in " + nfoFile + ". Aborting!")


### PR DESCRIPTION
Summary:
If exists, it uses the outline instead of the plot, because it's shorter (sometimes MUCH shorter) and easier to read.

Multiline Items:
Writers, Directors, Genres, Countries, Collections can read both multiple lines and one line separated by '/'.

VIDEO_TS:
Made one boolean to be used, to reduce the processing time.

Comments:
Made More readable.

Log:
Added/changed to log more data for easier debugging.
