### PR TITLE
Extended multipart recognition, added user changeable option to switch

### DIFF
--- a/XBMC .nfo Importer.bundle/Contents/DefaultPrefs.json
+++ b/XBMC .nfo Importer.bundle/Contents/DefaultPrefs.json
@@ -1,0 +1,8 @@
+[
+  {
+    "id":"plot",
+    "label":"use plot instead of outline",
+    "type":"bool",
+    "default":"false"
+  }
+]


### PR DESCRIPTION
between outline vs. plot for summary (should fix #20), switched order of poster names for slightly faster recognition of files matching current Frodo naming conventions, added recognition of "certification" tagged age ratings and extended release date recognition.
