### PR TITLE
Fix error when mpaa rating is missing and rework the rating

### DIFF
--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -44,13 +44,13 @@
   },
   {
     "id":"datestring",
-    "label":"format directive (see http://strftime.org/)",
+    "label":"format directive (see http://strftime.org/, * will match -,/ and .)",
     "type":"text",
-    "default":"%Y-%m-%d",
+    "default":"%Y*%m*%d",
   },
   {
     "id": "country",
-    "label": "Country (used for release date and content rating)",
+    "label": "Country (used for content rating)",
     "type": "enum",
     "values": [
       "",

--- a/Contents/Info.plist
+++ b/Contents/Info.plist
@@ -13,7 +13,7 @@
 	<key>PlexAgentAttributionText</key>
 	<string>
 <![CDATA[
-XBMCnfoMoviesImporter (V 1.1-0)
+XBMCnfoMoviesImporter (V 1.1-2)
 <br /><br />
 is an agent to import the local metadata XBMC creates when you export your library
 to seperate files. Movie poster and fanart will be recognized, if they are saved


### PR DESCRIPTION
recognition. (This should fix #50) Allow \* in date format directive for release dates
