### PR TITLE
fix: switch os.pathsep constant with os.sep

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -40,18 +40,18 @@ class xbmcnfo(Agent.Movies):
 		return (videoFileBase + fileExtension)
 
 	def getMovieNameFromFolder(self, folderpath, withYear):
-		foldersplit = folderpath.split (os.pathsep)
+		foldersplit = folderpath.split (os.sep)
 		if withYear == True:
 			if foldersplit[-1] == 'VIDEO_TS':
-				moviename = os.pathsep.join(foldersplit[1:len(foldersplit)-1:]) + os.pathsep + foldersplit[-2]
+				moviename = os.sep.join(foldersplit[1:len(foldersplit)-1:]) + os.sep + foldersplit[-2]
 			else:
-				moviename = os.pathsep.join(foldersplit) + os.pathsep + foldersplit[-1]
+				moviename = os.sep.join(foldersplit) + os.sep + foldersplit[-1]
 			self.DLog("Moviename from folder (withYear): " + moviename)
 		else:
 			if foldersplit[-1] == 'VIDEO_TS':
-				moviename = os.pathsep.join(foldersplit[1:len(foldersplit)-1:]) + os.pathsep + re.sub (r' \(.*\)',r'',foldersplit[-2])
+				moviename = os.sep.join(foldersplit[1:len(foldersplit)-1:]) + os.sep + re.sub (r' \(.*\)',r'',foldersplit[-2])
 			else:
-				moviename = os.pathsep.join(foldersplit) + os.pathsep + re.sub (r' \(.*\)',r'',foldersplit[-1])
+				moviename = os.sep.join(foldersplit) + os.sep + re.sub (r' \(.*\)',r'',foldersplit[-1])
 			self.DLog("Moviename from folder: " + moviename)
 		return moviename
 


### PR DESCRIPTION
Finding files in few formats always fail because of wrong path.
Example:
When finding poster file for media file **Z:\Filmy\Cyborg Girl (2008)\Cyborg Girl (2008) - Part01.avi**
It tries these:
1. Z:\Filmy\Cyborg Girl (2008)\Cyborg Girl (2008) - Part01-poster.jpg
2. **Z:\Filmy\Cyborg Girl (2008);Z:\Filmy\Cyborg Girl (2008)-poster.jpg**
3. **Z:\Filmy\Cyborg Girl (2008);Z:\Filmy\Cyborg Girl-poster.jpg**
4. Z:\Filmy\Cyborg Girl (2008)\poster.jpg
5. Z:\Filmy\Cyborg Girl (2008)\Cyborg Girl (2008) - Part01.tbn
