### PR TITLE
Add for contributing to Personal Media Agent

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -89,7 +89,8 @@ class XBMCNFO(PlexAgent):
 
     contributes_to = [
         'com.plexapp.agents.themoviedb',
-        'com.plexapp.agents.imdb'
+        'com.plexapp.agents.imdb',
+        'com.plexapp.agents.none'
     ]
 
 # ##### search function #####


### PR DESCRIPTION
Sometimes, I need to use personal media movie library (Personal Media Agent) with nfo agent for easy management of home movies. So I just added a line, and it seems to work! There might be some minor issues, but I think no problem right now.