### PR TITLE
Added preference option for creating collections from tags

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -682,13 +682,15 @@ class XBMCNFO(PlexAgent):
                     metadata.collections.add(setname)
                     log.debug('Added Collection from Set tag.')
                 # Collections (Tags)
-                try:
-                    tags = nfo_xml.xpath('tag')
-                    [metadata.collections.add(setname_pat.sub('', t.strip())) for tag_xml in tags for t in tag_xml.text.split('/')]
-                    log.debug('Added Collection(s) from tags.')
-                except:
-                    log.debug('Error adding Collection(s) from tags.')
-                    pass
+                if preferences['collectionsfromtags']:
+                    log.debug('Creating Collections from tags...')
+                    try:
+                        tags = nfo_xml.xpath('tag')
+                        [metadata.collections.add(setname_pat.sub('', t.strip())) for tag_xml in tags for t in tag_xml.text.split('/')]
+                        log.debug('Added Collection(s) from tags.')
+                    except:
+                        log.debug('Error adding Collection(s) from tags.')
+                        pass
                 # Duration
                 try:
                     log.debug('Trying to read <durationinseconds> tag from .nfo file...')

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -92,7 +92,7 @@
     "id":"collectionsfromtags",
     "label":"Enable generating Collections from tags\n_____________________________________________________________________________________",
     "type":"bool",
-    "default":"false"
+    "default":"true"
   },
   {
     "id": "country",

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -89,6 +89,12 @@
     "default":"false"
   },
   {
+    "id":"collectionsfromtags",
+    "label":"Enable generating Collections from tags\n_____________________________________________________________________________________",
+    "type":"bool",
+    "default":"false"
+  },
+  {
     "id": "country",
     "label": "Country (used for content rating)",
     "type": "enum",


### PR DESCRIPTION
Issue Addressed:
Original default action when reading the .nfo file was to fall-back to creating Collections from "tag" fields.

Solution:
Created a user configuration attribute for making this a toggled feature.

Extra info:
Some online dbs will return a ton of useless tags (_in this case tags refers to keywords_) when scraping. These tags were in my .nfo files from auto-scraping with a media manager. The result of this was my first run of this plug-in resulted in dozens of random collections being generated. 

I tested my code changes on my local machine only (Windows).